### PR TITLE
20221208_2: maintenance (JP) and other accessibility options

### DIFF
--- a/404.html
+++ b/404.html
@@ -49,7 +49,7 @@
     <div class="dis">
       <h1>E404: Page not found</h1>
       <p>
-        Return <a rel="noopener" href="/">home</a>
+        Return <a rel="noopener noreferrer" href="/">home</a>
       </p>
     </div>
   </body>

--- a/anniversary/1anniv/index.html
+++ b/anniversary/1anniv/index.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>#MamaNyoSquad @ 1</title>
     <link href="../../style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon/1anniv.png" type="image/x-icon">
+    <link rel="icon" href="../../media/favicon/1anniv.png" type="image/x-icon">
     <style>
       /* attach in-html custom css args here */
     </style>

--- a/anniversary/2anniv/index.html
+++ b/anniversary/2anniv/index.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>#MamaNyoSquad @ 2</title>
     <link href="../../style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon/2anniv.png" type="image/x-icon">
+    <link rel="icon" href="../../media/favicon/2anniv.png" type="image/x-icon">
     <style>
       /* attach in-html custom css args here */
     </style>

--- a/anniversary/index.html
+++ b/anniversary/index.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>#MamaNyoSquad's Inception Anniversaries</title>
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon.png" type="image/x-icon">
+    <link rel="icon" href="../media/favicon.png" type="image/x-icon">
     <style>
       /* attach in-html custom css args here */
     </style>
@@ -35,13 +35,13 @@
           <div class="annivlogo-head annivlogo2"></div>
         </div>
         <div class="HeadURLs">
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../">Home</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../policies">Policies</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../events">Events</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../archive">Archives</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../publishing">Publishing</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../blog">Disclosures</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../maintenance">Maintenance</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../">Home</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../policies">Policies</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../events">Events</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../archive">Archives</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../publishing">Publishing</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../blog">Disclosures</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../maintenance">Maintenance</a></span>
         </div>
       </div>
     </header>
@@ -67,7 +67,7 @@
               the community at best! Presented by the G.Mgr and the SocWeb Mgr.
             </p>
             <div class="ovlBtn">
-              <a rel="noopener" class="NyoBtn" href="1anniv">Presenter's Transcript</a>
+              <a rel="noopener noreferrer" class="NyoBtn" href="1anniv">Presenter's Transcript</a>
             </div>
           </div>
         </div>
@@ -82,7 +82,7 @@
               hype alive by other means! Presented by the G.Mgr.
             </p>
             <div class="ovlBtn">
-              <a rel="noopener" class="NyoBtn" href="2anniv">Presenter's Transcript</a>
+              <a rel="noopener noreferrer" class="NyoBtn" href="2anniv">Presenter's Transcript</a>
             </div>
           </div>
         </div>
@@ -98,12 +98,12 @@
         <div class="entertheuniverse"></div>
       </div>
       <div class="footerText">
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
         <br>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
         <br>
         <p style="font-weight: normal;">
           Licensed under Creative Commons - Attribution (CC-BY) 4.0 INTL and above
@@ -112,7 +112,7 @@
         </p>
       </div>
       <p class="tbmassoc">
-        <a rel="noopener" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
+        <a rel="noopener noreferrer" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
       </p>
     </footer>
   </body>

--- a/archive/20220604.html
+++ b/archive/20220604.html
@@ -5,7 +5,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>#MamaNyoSquad @ 2</title>
     <link href="https://mamanyosquad.github.io/style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon.png" type="image/x-icon">
+    <link rel="icon" href="../media/favicon.png" type="image/x-icon">
     <style>
       body {
         overflow: hidden;
@@ -75,11 +75,11 @@
     <div class="dis">
       <h1>Our 2nd Anniversary is just around the corner! 🎉</h1>
       <p>
-        As we are just half a year away from our 2nd Anniversary, we thought we might tease you a bit with some of our improvements so far! All modifications here are helmed by <a rel="noopener" href="https://mobile.twitter.com/thebelovedmoon" target="_blank">thebelovedmoon</a> using clever methods. Documentation to be posted whenever he sees fit.
+        As we are just half a year away from our 2nd Anniversary, we thought we might tease you a bit with some of our improvements so far! All modifications here are helmed by <a rel="noopener noreferrer" href="https://mobile.twitter.com/thebelovedmoon" target="_blank">thebelovedmoon</a> using clever methods. Documentation to be posted whenever he sees fit.
         <br><br>
-        This page is best viewed on desktops with a minimum display of 1080p. For the default landing page, see <a rel="noopener" href="../lp.html">lp.html</a>.
+        This page is best viewed on desktops with a minimum display of 1080p. For the default landing page, see <a rel="noopener noreferrer" href="../lp.html">lp.html</a>.
         <br><br>
-        Want to contribute? You may <a rel="noopener" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">fork</a> our repository from the deployment branch and submit a Pull Request from there. (You must be logged in to GitHub to perform this task.) This website is licensed under <a rel="noopener" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/blob/deploy/LICENSE" target="_blank">CC-BY 4.0 INTL</a>.
+        Want to contribute? You may <a rel="noopener noreferrer" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">fork</a> our repository from the deployment branch and submit a Pull Request from there. (You must be logged in to GitHub to perform this task.) This website is licensed under <a rel="noopener noreferrer" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/blob/deploy/LICENSE" target="_blank">CC-BY 4.0 INTL</a>.
       </p>
     </div>
   </body>

--- a/archive/20220708.html
+++ b/archive/20220708.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>1954年～2022年</title>
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon/ShinzoAbe_JAPAN.png" type="image/x-icon">
+    <link rel="icon" href="../media/favicon/ShinzoAbe_JAPAN.png" type="image/x-icon">
     <style>
       body {
         font-family: "Poppins", sans-serif;
@@ -113,9 +113,9 @@
     <div id="fadein" class="txt">
       <h1>Japan's Shinzo Abe has fallen. 🇯🇵</h1>
       <p>
-        Japan's Former Prime Minister Shinzo Abe (安倍晋三) has been assassinated 8 July 2022 at the Nara Area following his support for one politician in his fellow party. As of this update, we are still in the middle of mourning his loss. For more updates, please refer to this <a rel="noopener" href="https://google.com/search?q=shinzo+abe&source=lnms&tbm=nws" target="_blank">Google Search</a>.
+        Japan's Former Prime Minister Shinzo Abe (安倍晋三) has been assassinated 8 July 2022 at the Nara Area following his support for one politician in his fellow party. As of this update, we are still in the middle of mourning his loss. For more updates, please refer to this <a rel="noopener noreferrer" href="https://google.com/search?q=shinzo+abe&source=lnms&tbm=nws" target="_blank">Google Search</a>.
         <br><br>
-        For the default landing page, see <a rel="noopener" href="../lp.html">lp.html</a>.
+        For the default landing page, see <a rel="noopener noreferrer" href="../lp.html">lp.html</a>.
       </p>
     </div>
   </body>

--- a/archive/index.html
+++ b/archive/index.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>Main Page Archives</title>
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon.png" type="image/x-icon">
+    <link rel="icon" href="../media/favicon.png" type="image/x-icon">
     <style>
       /* attach in-html custom css args here */
     </style>
@@ -33,13 +33,13 @@
           <div class="annivlogo-head annivlogo2"></div>
         </div>
         <div class="HeadURLs" id="top">
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../">Home</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../policies">Policies</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../events">Events</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../">Home</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../policies">Policies</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../events">Events</a></span>
           <span class="HeadURLSpan Active">Archives</span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../publishing">Publishing</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../blog">Disclosures</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../maintenance">Maintenance</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../publishing">Publishing</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../blog">Disclosures</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../maintenance">Maintenance</a></span>
         </div>
       </div>
     </header>
@@ -54,13 +54,13 @@
       <div class="inThisArticle">
         <h2>In this article</h2>
         <ul>
-          <li><a rel="noopener" href="#sec1">Pre-overhaul</a></li>
+          <li><a rel="noopener noreferrer" href="#sec1">Pre-overhaul</a></li>
           <ul>
-            <li><a rel="noopener" href="#sec1.1">5 May 2020</a></li>
-            <li><a rel="noopener" href="#sec1.2">「WE VOTE FOR THE FUTURE.」</a></li>
-            <li><a rel="noopener" href="#sec1.3">#MamaNyoSquad @ 2</a></li>
-            <li><a rel="noopener" href="#sec1.4">1954年～2022年</a></li>
-            <li><a rel="noopener" href="#sec1.5">HM QUEEN ELIZABETH II, 1926 - 2022</a></li>
+            <li><a rel="noopener noreferrer" href="#sec1.1">5 May 2020</a></li>
+            <li><a rel="noopener noreferrer" href="#sec1.2">「WE VOTE FOR THE FUTURE.」</a></li>
+            <li><a rel="noopener noreferrer" href="#sec1.3">#MamaNyoSquad @ 2</a></li>
+            <li><a rel="noopener noreferrer" href="#sec1.4">1954年～2022年</a></li>
+            <li><a rel="noopener noreferrer" href="#sec1.5">HM QUEEN ELIZABETH II, 1926 - 2022</a></li>
           </ul>
         </ul>
       </div>
@@ -73,7 +73,7 @@
             (NTC) of the Philippines since 5 May 2020 PHT.
           </p>
           <div class="ovlBtn">
-            <a rel="noopener" class="NyoBtn" href="20220505.html" target="_blank">5 May 2020</a>
+            <a rel="noopener noreferrer" class="NyoBtn" href="20220505.html" target="_blank">5 May 2020</a>
           </div>
           <h3 id="sec1.2">「WE VOTE FOR THE FUTURE.」</h3>
           <p>
@@ -81,16 +81,16 @@
             booths to cast their votes.
           </p>
           <div class="ovlBtn">
-            <a rel="noopener" class="NyoBtn" href="20220509.html" target="_blank">「WE VOTE FOR THE FUTURE.」</a>
+            <a rel="noopener noreferrer" class="NyoBtn" href="20220509.html" target="_blank">「WE VOTE FOR THE FUTURE.」</a>
           </div>
           <h3 id="sec1.3">#MamaNyoSquad @ 2</h3>
           <p>
             This is the main page of the website before its overhaul started as a part of a bigger plan to
             restructure from scratch following the restrictions from the previous provider. For details, see
-            <a rel="noopener" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/tree/deploy/README.md" target="_blank">README</a>.
+            <a rel="noopener noreferrer" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/tree/deploy/README.md" target="_blank">README</a>.
           </p>
           <div class="ovlBtn">
-            <a rel="noopener" class="NyoBtn" href="20220604.html" target="_blank">#MamaNyoSquad @ 2</a>
+            <a rel="noopener noreferrer" class="NyoBtn" href="20220604.html" target="_blank">#MamaNyoSquad @ 2</a>
           </div>
           <h3 id="sec1.4">1954年～2022年</h3>
           <p>
@@ -98,7 +98,7 @@
             during his speech at the Nara area. #MamaNyoSquad and its pact send its condolences to his families.
           </p>
           <div class="ovlBtn">
-            <a rel="noopener" class="NyoBtn" href="20220708.html" target="_blank">1954年～2022年</a>
+            <a rel="noopener noreferrer" class="NyoBtn" href="20220708.html" target="_blank">1954年～2022年</a>
           </div>
           <h3 id="sec1.5">HM QUEEN ELIZABETH II, 1926 - 2022</h3>
           <p>
@@ -106,7 +106,7 @@
             Open Letter of Condolence to the Royal Family.
           </p>
           <div class="ovlBtn">
-            <a rel="noopener" class="NyoBtn" href="20220908.html" target="_blank">HM QUEEN ELIZABETH II, 1926 - 2022</a>
+            <a rel="noopener noreferrer" class="NyoBtn" href="20220908.html" target="_blank">HM QUEEN ELIZABETH II, 1926 - 2022</a>
           </div>
       </div>
     </div>
@@ -115,12 +115,12 @@
         <div class="entertheuniverse"></div>
       </div>
       <div class="footerText">
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
         <br>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
         <br>
         <p style="font-weight: normal;">
           Licensed under Creative Commons - Attribution (CC-BY) 4.0 INTL and above
@@ -129,7 +129,7 @@
         </p>
       </div>
       <p class="tbmassoc">
-        <a rel="noopener" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
+        <a rel="noopener noreferrer" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
       </p>
     </footer>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>Disclosures</title>
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon.png" type="image/x-icon">
+    <link rel="icon" href="../media/favicon.png" type="image/x-icon">
     <style>
       .dis {
         position: absolute;

--- a/css/homefeed.css
+++ b/css/homefeed.css
@@ -56,8 +56,8 @@
   }
 
 header {
-  position: sticky;
   position: -webkit-sticky;
+  position: sticky;
   top: 0;
   z-index: 1;
 }

--- a/css/publishing.css
+++ b/css/publishing.css
@@ -28,8 +28,8 @@ footer {
 }
 
 header {
-  position: sticky;
   position: -webkit-sticky;
+  position: sticky;
   top: 0;
   z-index: 1;
 }

--- a/events/index.html
+++ b/events/index.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>Events</title>
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon.png" type="image/x-icon">
+    <link rel="icon" href="../media/favicon.png" type="image/x-icon">
     <style>
       .dis {
         position: absolute;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>#MamaNyoSquad @ 2</title>
     <link href="style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon.png" type="image/x-icon">
+    <link rel="icon" href="media/favicon.png" type="image/x-icon">
     <style>
       /* attach in-html custom css args here */
     </style>
@@ -39,12 +39,12 @@
         </div>
         <div class="HeadURLs">
           <span class="HeadURLSpan Active">Home</span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="policies">Policies</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="events">Events</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="archive">Archives</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="publishing">Publishing</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="blog">Disclosures</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="maintenance">Maintenance</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="policies">Policies</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="events">Events</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="archive">Archives</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="publishing">Publishing</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="blog">Disclosures</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="maintenance">Maintenance</a></span>
         </div>
       </div>
     </header>
@@ -58,7 +58,7 @@
     <div class="InceptAnniv">
       <h1>Take a look at our Inception Anniversaries!</h1>
       <div class="ovlBtn">
-        <a rel="noopener" class="NyoBtn" href="anniversary">Inception Anniversaries</a>
+        <a rel="noopener noreferrer" class="NyoBtn" href="anniversary">Inception Anniversaries</a>
       </div>
     </div>
     <div class="GeneralDiv">
@@ -66,11 +66,11 @@
       <div class="MamaNyo19-row">
         <div class="dualfeed-row">
           <div class="dualfeed-col">
-            <a rel="noopener" class="twitter-timeline" data-lang="en" data-height="950" data-dnt="true" data-theme="dark" href="https://twitter.com/MamaNyoSquad">Tweets by @MamaNyoSquad</a>
+            <a rel="noopener noreferrer" class="twitter-timeline" data-lang="en" data-height="950" data-dnt="true" data-theme="dark" href="https://twitter.com/MamaNyoSquad">Tweets by @MamaNyoSquad</a>
             <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
           </div>
           <div class="dualfeed-col">
-            <a rel="noopener" class="twitter-timeline" data-lang="en" data-height="950" data-dnt="true" data-theme="dark" href="https://twitter.com/doax_vv_staff">Tweets by @doax_vv_staff</a>
+            <a rel="noopener noreferrer" class="twitter-timeline" data-lang="en" data-height="950" data-dnt="true" data-theme="dark" href="https://twitter.com/doax_vv_staff">Tweets by @doax_vv_staff</a>
             <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
           </div>
         </div>
@@ -81,12 +81,12 @@
         <div class="entertheuniverse"></div>
       </div>
       <div class="footerText">
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
         <br>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
         <br>
         <p style="font-weight: normal;">
           Licensed under Creative Commons - Attribution (CC-BY) 4.0 INTL and above
@@ -95,7 +95,7 @@
         </p>
       </div>
       <p class="tbmassoc">
-        <a rel="noopener" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
+        <a rel="noopener noreferrer" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
       </p>
     </footer>
   </body>
@@ -155,7 +155,7 @@
         <div class="MamaNyo19-Japanese"></div>
       </div>
       <div class="ovlBtn">
-        <a rel="noopener" class="NyoBtn" href="[Japanese Edition]" target="_blank">Japanese Edition</a>
+        <a rel="noopener noreferrer" class="NyoBtn" href="[Japanese Edition]" target="_blank">Japanese Edition</a>
       </div>
     </div>
     <div class="MamaNyo19-col">
@@ -163,7 +163,7 @@
         <div class="MamaNyo19-Global"></div>
       </div>
       <div class="ovlBtn">
-        <a rel="noopener" class="NyoBtn" href="[Global Edition]" target="_blank">Global Edition</a>
+        <a rel="noopener noreferrer" class="NyoBtn" href="[Global Edition]" target="_blank">Global Edition</a>
       </div>
     </div>
     (this part will be for other stuff related to the event)
@@ -173,14 +173,14 @@
   Venus Inception - Japanese
 
   <div class="VenusIncept">
-    <b>シャンディがグローバル版27代目ヴィーナスに就任しました! 詳しくは<a rel="noopener" class="HeadURL" href="[Japanese Edition]" target="_blank">こちら</a>。</b>
+    <b>シャンディがグローバル版27代目ヴィーナスに就任しました! 詳しくは<a rel="noopener noreferrer" class="HeadURL" href="[Japanese Edition]" target="_blank">こちら</a>。</b>
   </div>
 
 
   Venus Inception - Global
 
   <div class="VenusIncept">
-    <b>Koharu has just been incepted as the 25th Venus of the Global Edition! More <a rel="noopener" class="HeadURL" href="[Global Edition]" target="_blank">here</a>.</b>
+    <b>Koharu has just been incepted as the 25th Venus of the Global Edition! More <a rel="noopener noreferrer" class="HeadURL" href="[Global Edition]" target="_blank">here</a>.</b>
   </div>
 
 -->

--- a/lp.html
+++ b/lp.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>#MamaNyoSquad</title>
     <link href="style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon.png" type="image/x-icon">
+    <link rel="icon" href="media/favicon.png" type="image/x-icon">
     <style>
       .dis {
         position: absolute;
@@ -56,14 +56,14 @@
     <div class="dis">
       <h1>We are going open-source! 💕</h1>
       <p>
-        In a few commits, our web presence returns as we have undergone a major migration and overhaul! Read our <a rel="noopener" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/blob/deploy/README.md" target="_blank">README</a> for details.
+        In a few commits, our web presence returns as we have undergone a major migration and overhaul! Read our <a rel="noopener noreferrer" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/blob/deploy/README.md" target="_blank">README</a> for details.
         <br><br>
-        Read more about our <a rel="noopener" href="policies">Site Policies</a> to understand how we manage our workflow. We have archived our Main Page modifications that reflect recent events at the <a rel="noopener" href="archive">Archives</a>.
+        Read more about our <a rel="noopener noreferrer" href="policies">Site Policies</a> to understand how we manage our workflow. We have archived our Main Page modifications that reflect recent events at the <a rel="noopener noreferrer" href="archive">Archives</a>.
         <br><br>
         <b><i>Enter the universe through the eyes of the Tengu!</i></b>
       </p>
       <br>
-      <p><b>WE HAVE A NEW OVERHAUL!</b> Click <a rel="noopener" href="/">here</a>.</p>
+      <p><b>WE HAVE A NEW OVERHAUL!</b> Click <a rel="noopener noreferrer" href="/">here</a>.</p>
     </div>
   </body>
 </html>

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>Maintenance Tracker</title>
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon.png" type="image/x-icon">
+    <link rel="icon" href="../media/favicon.png" type="image/x-icon">
     <style>
       /* attach in-html custom css args here */
     </style>
@@ -34,12 +34,12 @@
           <div class="annivlogo-head annivlogo2"></div>
         </div>
         <div class="HeadURLs" id="top">
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../">Home</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../policies">Policies</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../events">Events</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../archive">Archives</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../publishing">Publishing</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../blog">Disclosures</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../">Home</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../policies">Policies</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../events">Events</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../archive">Archives</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../publishing">Publishing</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../blog">Disclosures</a></span>
           <span class="HeadURLSpan Active">Maintenance</span>
         </div>
       </div>
@@ -54,15 +54,15 @@
       <div class="inThisArticle">
         <h2>In this article</h2>
         <ul>
-          <li><a rel="noopener" href="#sec1">Japanese Edition</a></li>
-          <li><a rel="noopener" href="#sec2">Global Edition</a></li>
+          <li><a rel="noopener noreferrer" href="#sec1">Japanese Edition</a></li>
+          <li><a rel="noopener noreferrer" href="#sec2">Global Edition</a></li>
         </ul>
       </div>
       <div class="secContain">
         <h2 id="sec1">Japanese Edition</h2>
         <p class="statustext">
           <!-- queued, active or finished -->
-          Status: <span class="queued"></span>
+          Status: <span class="active"></span>
         </p>
         <h3>English</h3>
         <p>
@@ -85,7 +85,7 @@
           </ul>
         </p>
         <div class="ovlBtn">
-          <a rel="noopener" class="NyoBtn" href="https://doax-venusvacation.jp/maintenance/33036.html" target="_blank">Details / 詳細へ</a>
+          <a rel="noopener noreferrer" class="NyoBtn" href="https://doax-venusvacation.jp/maintenance/33036.html" target="_blank">Details / 詳細へ</a>
         </div>
       </div>
       <div class="secContain">
@@ -103,7 +103,7 @@
           </ul>
         </p>
         <div class="ovlBtn">
-          <a rel="noopener" class="NyoBtn" href="https://game.doaxvv.com/production/html/information/maint_gl_0434_221208_1_0_f392d0afccab3dfab76afbbb429b6317b374afbe944452e2152b4f74315157b1_en.html" target="_blank">Details</a>
+          <a rel="noopener noreferrer" class="NyoBtn" href="https://game.doaxvv.com/production/html/information/maint_gl_0434_221208_1_0_f392d0afccab3dfab76afbbb429b6317b374afbe944452e2152b4f74315157b1_en.html" target="_blank">Details</a>
         </div>
       </div>
       <p>
@@ -115,12 +115,12 @@
         <div class="entertheuniverse"></div>
       </div>
       <div class="footerText">
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
         <br>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
         <br>
         <p style="font-weight: normal;">
           Licensed under Creative Commons - Attribution (CC-BY) 4.0 INTL and above
@@ -129,7 +129,7 @@
         </p>
       </div>
       <p class="tbmassoc">
-        <a rel="noopener" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
+        <a rel="noopener noreferrer" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
       </p>
     </footer>
   </body>

--- a/openlettertwitter/index.html
+++ b/openlettertwitter/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -140,12 +140,12 @@
     </div>
     <footer>
       <p>
-        Want to keep in touch? Email us at <a rel="noopener" href="mailto:mamanyosquad@outlook.com">mamanyosquad@outlook.com</a>
+        Want to keep in touch? Email us at <a rel="noopener noreferrer" href="mailto:mamanyosquad@outlook.com">mamanyosquad@outlook.com</a>
       </p>
       <p>
         CC/BCC us so that we can get in touch with you easily (or email us separately):
-        <a rel="noopener" href="mailto:jelsa14018@gmail.com">G.Mgr</a> |
-        <a rel="noopener" href="mailto:ortega082@outlook.com">SocWeb Mgr</a>
+        <a rel="noopener noreferrer" href="mailto:jelsa14018@gmail.com">G.Mgr</a> |
+        <a rel="noopener noreferrer" href="mailto:ortega082@outlook.com">SocWeb Mgr</a>
       </p>
     </footer>
   </body>

--- a/policies/index.html
+++ b/policies/index.html
@@ -6,7 +6,7 @@
     <meta name="author" content="#MamaNyoSquad">
     <title>Site Policies</title>
     <link href="../style.css" rel="stylesheet" type="text/css" media="all">
-    <link rel="icon" href="https://mamanyosquad.github.io/media/favicon.png" type="image/x-icon">
+    <link rel="icon" href="../media/favicon.png" type="image/x-icon">
     <style>
       /* attach in-html custom css args here */
     </style>
@@ -33,13 +33,13 @@
           <div class="annivlogo-head annivlogo2"></div>
         </div>
         <div class="HeadURLs">
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../">Home</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../">Home</a></span>
           <span class="HeadURLSpan Active">Policies</span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../events">Events</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../archive">Archives</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../publishing">Publishing</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../blog">Disclosures</a></span>
-          <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="../maintenance">Maintenance</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../events">Events</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../archive">Archives</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../publishing">Publishing</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../blog">Disclosures</a></span>
+          <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="../maintenance">Maintenance</a></span>
         </div>
       </div>
     </header>
@@ -53,26 +53,26 @@
       </i></p>
       <p>
         For the recent updates about this page, please refer to the
-        <a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/commits/deploy/policies" target="_blank"><code>deploy</code></a>
+        <a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/commits/deploy/policies" target="_blank"><code>deploy</code></a>
         branch.
       </p>
       <div class="inThisArticle">
         <h2>In this article</h2>
         <ul>
-          <li><a rel="noopener" href="#sec1">General Site Policies</a></li>
+          <li><a rel="noopener noreferrer" href="#sec1">General Site Policies</a></li>
           <ul>
-            <li><a rel="noopener" href="#sec1.1">Cookies</a></li>
-            <li><a rel="noopener" href="#sec1.2">Content Moderation</a></li>
-            <li><a rel="noopener" href="#sec1.3">Usage of Content from Other Sources</a></li>
-            <li><a rel="noopener" href="#sec1.4">Hosting Provider Policy</a></li>
+            <li><a rel="noopener noreferrer" href="#sec1.1">Cookies</a></li>
+            <li><a rel="noopener noreferrer" href="#sec1.2">Content Moderation</a></li>
+            <li><a rel="noopener noreferrer" href="#sec1.3">Usage of Content from Other Sources</a></li>
+            <li><a rel="noopener noreferrer" href="#sec1.4">Hosting Provider Policy</a></li>
           </ul>
-          <li><a rel="noopener" href="#sec2">KT Disclosure</a></li>
+          <li><a rel="noopener noreferrer" href="#sec2">KT Disclosure</a></li>
           <ul>
-            <li><a rel="noopener" href="#sec2.1">Introduction</a></li>
-            <li><a rel="noopener" href="#sec2.2">Handling the Assets</a></li>
-            <li><a rel="noopener" href="#sec2.3">Properties</a></li>
-            <li><a rel="noopener" href="#sec2.4">Additional Information</a></li>
-            <li><a rel="noopener" href="#sec2.5">Conclusion</a></li>
+            <li><a rel="noopener noreferrer" href="#sec2.1">Introduction</a></li>
+            <li><a rel="noopener noreferrer" href="#sec2.2">Handling the Assets</a></li>
+            <li><a rel="noopener noreferrer" href="#sec2.3">Properties</a></li>
+            <li><a rel="noopener noreferrer" href="#sec2.4">Additional Information</a></li>
+            <li><a rel="noopener noreferrer" href="#sec2.5">Conclusion</a></li>
           </ul>
         </ul>
       </div>
@@ -92,7 +92,7 @@
             services</strong>. Their respective Policies apply:
             <ul>
               <li>GitHub (see "Hosting Provider Policy")</li>
-              <li><a rel="noopener" href="https://twitter.com/privacy" target="_blank">Twitter</a></li>
+              <li><a rel="noopener noreferrer" href="https://twitter.com/privacy" target="_blank">Twitter</a></li>
             </ul>
           </p>
           <h3 id="sec1.2">Content Moderation</h3>
@@ -117,7 +117,7 @@
           <h3 id="sec1.4">Hosting Provider Policy</h3>
           <p>
             Learn more about how GitHub collects and processes information via this
-            <a rel="noopener" href="http://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement" target="_blank">documentation</a>.
+            <a rel="noopener noreferrer" href="http://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement" target="_blank">documentation</a>.
           </p>
       </div>
       <div class="secContain">
@@ -160,8 +160,8 @@
           <p>
             We may be prompted to remove the assets and/or take down if they deem we violated their
             properties, with or without question. In case of infringement, please contact us by
-            <a rel="noopener" href="mailto:mamanyosquad@outlook.com">Email</a> or
-            <a rel="noopener" href="https://mobile.twitter.com/messages/compose?recipient_id=1335516811505254401" target="_blank">Twitter DM</a>.
+            <a rel="noopener noreferrer" href="mailto:mamanyosquad@outlook.com">Email</a> or
+            <a rel="noopener noreferrer" href="https://mobile.twitter.com/messages/compose?recipient_id=1335516811505254401" target="_blank">Twitter DM</a>.
           </p>
           <p>
             We may also send them a formal permission to use the assets as long as such are not
@@ -198,12 +198,12 @@
         <div class="entertheuniverse"></div>
       </div>
       <div class="footerText">
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://mobile.twitter.com/MamaNyoSquad" target="_blank">Twitter</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://youtube.com/@MamaNyoSquad" target="_blank">YouTube</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="mailto:mamanyosquad@outlook.com">Email</a></span>
         <br>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
-        <span class="HeadURLSpan"><a rel="noopener" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io" target="_blank">GitHub Repository</a></span>
+        <span class="HeadURLSpan"><a rel="noopener noreferrer" class="HeadURL" href="https://github.com/MamaNyoSquad/mamanyosquad.github.io/fork" target="_blank">Fork and Improve</a></span>
         <br>
         <p style="font-weight: normal;">
           Licensed under Creative Commons - Attribution (CC-BY) 4.0 INTL and above
@@ -212,7 +212,7 @@
         </p>
       </div>
       <p class="tbmassoc">
-        <a rel="noopener" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
+        <a rel="noopener noreferrer" class="HeadURL" href="https://thebelovedmoon.wixsite.com/tbmassoc?lang=en" target="_blank">a tbmassoc brand</a>
       </p>
     </footer>
   </body>

--- a/publishing/index.html
+++ b/publishing/index.html
@@ -217,7 +217,7 @@
               <div class="ISepisodes">
                 <div class="episode-ovl">
                   <div class="episode">
-                    <a rel="noopener" class="epURL" title="Deep Arrogance - Nagisa's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/deep-arrogance-nagisa-s-inside-story-752432" target="_blank"></a>
+                    <a rel="noopener noreferrer" class="epURL" title="Deep Arrogance - Nagisa's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/deep-arrogance-nagisa-s-inside-story-752432" target="_blank"></a>
                     <div class="epHead ep1"></div>
                     <div class="epText">
                       <div>
@@ -232,7 +232,7 @@
                 </div>
                 <div class="episode-ovl">
                   <div class="episode">
-                    <a rel="noopener" class="epURL" title="Admirant of the Past - Fiona's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/admirant-of-the-past-fiona-s-inside-story-760169" target="_blank"></a>
+                    <a rel="noopener noreferrer" class="epURL" title="Admirant of the Past - Fiona's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/admirant-of-the-past-fiona-s-inside-story-760169" target="_blank"></a>
                     <div class="epHead ep2"></div>
                     <div class="epText">
                       <div>
@@ -247,7 +247,7 @@
                 </div>
                 <div class="episode-ovl">
                   <div class="episode">
-                    <a rel="noopener" class="epURL" title="Admirant of the Present - Tsukushi's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/admirant-of-the-present-tsukushi-s-inside-story-835875" target="_blank"></a>
+                    <a rel="noopener noreferrer" class="epURL" title="Admirant of the Present - Tsukushi's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/admirant-of-the-present-tsukushi-s-inside-story-835875" target="_blank"></a>
                     <div class="epHead ep3"></div>
                     <div class="epText">
                       <div>
@@ -261,7 +261,7 @@
                 </div>
                 <div class="episode-ovl">
                   <div class="episode">
-                    <a rel="noopener" class="epURL" title="Admirant of the Future - Nyotengu's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/admirant-of-the-future-nyotengu-s-inside-story-886954" target="_blank"></a>
+                    <a rel="noopener noreferrer" class="epURL" title="Admirant of the Future - Nyotengu's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/admirant-of-the-future-nyotengu-s-inside-story-886954" target="_blank"></a>
                     <div class="epHead ep4"></div>
                     <div class="epText">
                       <div>
@@ -276,7 +276,7 @@
                 </div>
                 <div class="episode-ovl">
                   <div class="episode">
-                    <a rel="noopener" class="epURL" title="Everything Went Dark - Luna's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/everything-went-dark-luna-s-inside-story-886955" target="_blank"></a>
+                    <a rel="noopener noreferrer" class="epURL" title="Everything Went Dark - Luna's Inside Story" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/everything-went-dark-luna-s-inside-story-886955" target="_blank"></a>
                     <div class="epHead ep5"></div>
                     <div class="epText">
                       <div>
@@ -290,7 +290,7 @@
                 </div>
                 <div class="episode-ovl">
                   <div class="episode">
-                    <a rel="noopener" class="epURL" title="Romantic Perception - Helena's Inside Story Pt.1" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/romantic-perception-helena-s-inside-story-pt-1-1005683" target="_blank"></a>
+                    <a rel="noopener noreferrer" class="epURL" title="Romantic Perception - Helena's Inside Story Pt.1" href="https://www.getrevue.co/profile/VenusVIDiaries/issues/romantic-perception-helena-s-inside-story-pt-1-1005683" target="_blank"></a>
                     <div class="epHead ep6"></div>
                     <div class="epText">
                       <div>


### PR DESCRIPTION
in this update:
- Japanese Edition: **ACTIVE**
- added `noreferrer` to `<a> rel` attribute
- revert favicon references (except 404 page wc is global)
- plugin priority before main in css args