### PR TITLE
20231114

### DIFF
--- a/404.html
+++ b/404.html
@@ -30,7 +30,7 @@
   </head>
   <body onload="launch()">
     <div class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <header>
       <div class="siteHEADER">

--- a/anniversary/index.html
+++ b/anniversary/index.html
@@ -39,7 +39,7 @@
   </head>
   <body onload="launch()">
     <div class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <header>
       <div class="siteHEADER">

--- a/archive/index.html
+++ b/archive/index.html
@@ -37,7 +37,7 @@
   </head>
   <body onload="launch()">
     <div class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <header>
       <div class="siteHEADER">

--- a/blog/20230902/sinoTimer.js
+++ b/blog/20230902/sinoTimer.js
@@ -10,6 +10,7 @@ function sinoTimer() {
     var s = ("0" + Math.floor((distance % (1000 * 60)) / 1000)).slice(-2);
     document.getElementById("sinoTime").innerHTML = d + ":" + h + ":" + m + ":" + s;
     if (distance <= 0) {
+      interactModeOn();
       clearInterval(timer);
       document.getElementById("sinoTime").innerHTML = "00:00:00:00";
       eventEnd();
@@ -21,13 +22,103 @@ function sinoDayCount() {
   const timer = setInterval(function() {
     const now = new Date().getTime();
     const distance = time - now;
+    /* calculate timers */
     var d = ("0" + Math.floor(distance / (1000 * 60 * 60 * 24))).slice(-2);
-    var dnum = Number(d);
-    dnum += 1;
+    var h = ("0" + Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))).slice(-2);
+    var m = ("0" + Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60))).slice(-2);
+    /* add 1 */
+    var dnum = Number(d), hnum = Number(h), mnum = Number(m);
+    dnum += 1, hnum += 1, mnum += 1;
+    /* do complicated ifs, powered by UNIX distance */
     document.getElementById("sinoDayCount").innerHTML = dnum + " days";
+    if (distance <= 86400000) {
+      document.getElementById("sinoDayCount").innerHTML = hnum + " hours";
+    }
+    if (distance <= 3600000) {
+      document.getElementById("sinoDayCount").innerHTML = mnum + " minutes";
+    }
+    if (distance <= 60000) {
+      document.getElementById("sinoOver").innerHTML = "In 60 seconds, the Library will be closed."
+    }
+    /* when the timer reaches zero.. */
     if (distance <= 0) {
       clearInterval(timer);
       document.getElementById("sinoOver").innerHTML = "The Library is officially closed. Thank you for playing SINoALICE Global Edition.";
     }
   }, 0);
+}
+
+function _0x3334() {
+  const _0x1e682c = [
+    "innerHTML",
+    "16UTGTWC",
+    "37ushYez",
+    "1783856FCEmsI",
+    "351390WqDeKG",
+    "block",
+    "style",
+    "2176938AoSbYF",
+    "6842gHpheA",
+    "none",
+    "1162126mqLPep",
+    "unixSinoTime",
+    "sinoTime",
+    "540675TZjyou",
+    "221220UFcQWv",
+    "display",
+    "500ifrtXN",
+    "getElementById",
+  ];
+  _0x3334 = function () {
+    return _0x1e682c;
+  };
+  return _0x3334();
+}
+(function (_0x50af5e, _0xaac238) {
+  const _0x3b6fc4 = _0x4bca,
+    _0x48d0ac = _0x50af5e();
+  while (!![]) {
+    try {
+      const _0x10f807 =
+        (-parseInt(_0x3b6fc4(0x120)) / 0x1) *
+          (-parseInt(_0x3b6fc4(0x126)) / 0x2) +
+        parseInt(_0x3b6fc4(0x122)) / 0x3 +
+        -parseInt(_0x3b6fc4(0x121)) / 0x4 +
+        -parseInt(_0x3b6fc4(0x119)) / 0x5 +
+        -parseInt(_0x3b6fc4(0x125)) / 0x6 +
+        (parseInt(_0x3b6fc4(0x116)) / 0x7) *
+          (-parseInt(_0x3b6fc4(0x11f)) / 0x8) +
+        (-parseInt(_0x3b6fc4(0x11a)) / 0x9) *
+          (-parseInt(_0x3b6fc4(0x11c)) / 0xa);
+      if (_0x10f807 === _0xaac238) break;
+      else _0x48d0ac["push"](_0x48d0ac["shift"]());
+    } catch (_0x2171d1) {
+      _0x48d0ac["push"](_0x48d0ac["shift"]());
+    }
+  }
+})(_0x3334, 0x36a05);
+function _0x4bca(_0x575917, _0x3959c8) {
+  const _0x3334f8 = _0x3334();
+  return (
+    (_0x4bca = function (_0x4bcaf5, _0x5d4004) {
+      _0x4bcaf5 = _0x4bcaf5 - 0x115;
+      let _0xea5939 = _0x3334f8[_0x4bcaf5];
+      return _0xea5939;
+    }),
+    _0x4bca(_0x575917, _0x3959c8)
+  );
+}
+function changeToDistance() {
+  const _0x3e8a40 = setInterval(function () {
+    const _0x51f5a5 = _0x4bca,
+      _0x40bccb = new Date()["getTime"](),
+      _0x3d5a69 = time - _0x40bccb;
+    (document["getElementById"](_0x51f5a5(0x118))[_0x51f5a5(0x124)][
+      _0x51f5a5(0x11b)
+    ] = _0x51f5a5(0x115)),
+      (document[_0x51f5a5(0x11d)](_0x51f5a5(0x117))["style"][_0x51f5a5(0x11b)] =
+        _0x51f5a5(0x123)),
+      (document[_0x51f5a5(0x11d)](_0x51f5a5(0x117))[_0x51f5a5(0x11e)] =
+        _0x3d5a69);
+  }, 0x0);
 }

--- a/blog/index.html
+++ b/blog/index.html
@@ -37,7 +37,7 @@
   </head>
   <body onload="launch()">
     <div class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <header>
       <div class="siteHEADER">

--- a/events/index.html
+++ b/events/index.html
@@ -37,7 +37,7 @@
   </head>
   <body onload="launch()">
     <div class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <header>
       <div class="siteHEADER">

--- a/events/thelonelybride-sinoalice/index.html
+++ b/events/thelonelybride-sinoalice/index.html
@@ -34,9 +34,17 @@
         sinoTimer();
         autoPlayStream();
       }
+      function noInteract() {
+        document.getElementById("no-input").style.pointerEvents = "none";
+        document.getElementById("no-input").style.overflow = "hidden";
+      }
+      function interactModeOn() {
+        document.getElementById("no-input").style.pointerEvents = "all";
+        document.getElementById("no-input").style.overflow = "auto";
+      }
     </script>
   </head>
-  <body onload="launch()">
+  <body id="no-input" onload="launch()">
     <div id="makeSnowWhiteDisappear" class="snowWhite"></div>
     <div id="sinoEnd" class="textarea">
       <img src="../../media/images/bride_3.png" alt="">

--- a/events/thelonelybride-sinoalice/scripts.js
+++ b/events/thelonelybride-sinoalice/scripts.js
@@ -21,8 +21,9 @@ function autoPlayStream() {
   const timer = setInterval(function() {
     const now = new Date().getTime();
     const distance = time - now;
-    if (distance <= 42000000) {
+    if (distance <= 4200000) {
       window.location.hash = "streamGoesHere";
+      noInteract();
     }
   }, 0);
 }

--- a/index.html
+++ b/index.html
@@ -153,12 +153,13 @@
         document.getElementById("removeBtnStream").remove();
         document.getElementById("playAudio").src = "";
         window.location.hash = "streamGoesHere";
+        noInteract();
       }
       function autoPlayStream() {
         const timer = setInterval(function() {
           const now = new Date().getTime();
           const distance = time - now;
-          if (distance <= 42000000) {
+          if (distance <= 4200000) {
             pageLaunch();
             revealEmbed();
           }
@@ -182,9 +183,19 @@
           "</div>";
         pageLaunch();
       }
+      function noInteract() {
+        document.getElementById("no-input").style.pointerEvents = "none";
+        document.getElementById("no-input").style.overflow = "hidden";
+      }
+      function interactModeOn() {
+        document.getElementById("no-input").style.pointerEvents = "all";
+        document.getElementById("no-input").style.overflow = "auto";
+        document.body.scrollTop = 0;
+        document.documentElement.scrollTop = 0;
+      }
     </script>
   </head>
-  <body onload="launch()">
+  <body id="no-input" onload="launch()">
     <div onclick="pageLaunch()">
       <div id="loadOVL">
         <div id="load">
@@ -198,7 +209,7 @@
     <!-- <audio id="playAudio" src="media/audio/20230902_sinoalice_home.mp3" width="0" height="0" loop></audio> -->
     <audio id="playAudio" src="media/audio/20231108_sinoSayonara.mp3" width="0" height="0" loop></audio>
     <div id="removeElement" class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <div id="sinoEnd">
       <div id="streamGoesHere">
@@ -217,6 +228,7 @@
         </p>
         <br>
         <p id="sinoTime" class="large"></p>
+        <p id="unixSinoTime" class="large" style="display: none;"></p>
         <br>
         <h2>SINoALICE Global will end soon.</h2>
         <p>
@@ -417,7 +429,7 @@
     </iframe>
     ->
     <div class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <header>
       <div class="siteHEADER">

--- a/kt-disclosure/index.html
+++ b/kt-disclosure/index.html
@@ -39,7 +39,7 @@
   <body onload="launch()">
     <header>
       <div class="ImportantHEAD">
-        <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+        <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
       </div>
       <div class="siteHEADER" style="box-shadow: 0 9.5px 19px #ffffff;">
         <div class="logoHead">

--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -43,7 +43,7 @@
   </head>
   <body onload="launch()">
     <div class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <header>
       <div class="siteHEADER">

--- a/policies/index.html
+++ b/policies/index.html
@@ -37,7 +37,7 @@
   </head>
   <body onload="launch()">
     <div class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <header>
       <div class="siteHEADER">

--- a/publishing/index.html
+++ b/publishing/index.html
@@ -47,7 +47,7 @@
       </div>
     </a>
     <div class="ImportantHEAD">
-      <b id="sinoOver">We're just <span id="sinoDayCount">NaN days</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
+      <b id="sinoOver">We're just <span id="sinoDayCount">NaN</span> before the sealing of the Library for Global Edition. Join us in reliving SINoALICE's legacy for the final time.</b>
     </div>
     <header>
       <div class="head">


### PR DESCRIPTION
in this update:
- 24hrs..
- added additional banners for `sinoTime`
- figured out how to set a page and prevent input until zero (with `noInteract()`)
- fixed unix distance maths for setting with banner block
- fixed the "bug" where `#streamGoesHere` triggers earlier than intended.. unix distance maths
- `interactModeOn()` when timer reaches zero
- had to obfuscate a part of `sinoTimer.js` for obv reasons.. send help.